### PR TITLE
feat: 区分Docker与本地环境的浏览器启动

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ WORKDIR /app
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
+# 新增环境变量，用于区分Docker环境和本地环境
+ENV RUNNING_IN_DOCKER=true
 # 告知 Playwright 在哪里找到浏览器
 ENV PLAYWRIGHT_BROWSERS_PATH=/root/.cache/ms-playwright
 

--- a/login.py
+++ b/login.py
@@ -6,7 +6,7 @@ from playwright.async_api import async_playwright
 # 定义保存登录状态的文件路径
 STATE_FILE = "xianyu_state.json"
 LOGIN_IS_EDGE = os.getenv("LOGIN_IS_EDGE", "false").lower() == "true"
-
+RUNNING_IN_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false").lower() == "true"
 
 
 async def main():
@@ -16,8 +16,11 @@ async def main():
         if LOGIN_IS_EDGE:
             browser = await p.chromium.launch(headless=False, channel="msedge")
         else:
-            # 明确指定使用系统安装的 Chrome 浏览器，以绕过 Playwright 的内部浏览器管理问题
-            browser = await p.chromium.launch(headless=False, channel="chrome")
+            # Docker环境内，使用Playwright自带的chromium；本地环境，使用系统安装的Chrome
+            if RUNNING_IN_DOCKER:
+                browser = await p.chromium.launch(headless=False)
+            else:
+                browser = await p.chromium.launch(headless=False, channel="chrome")
         context = await browser.new_context()
         page = await context.new_page()
 

--- a/spider_v2.py
+++ b/spider_v2.py
@@ -36,6 +36,7 @@ WX_BOT_URL = os.getenv("WX_BOT_URL")
 PCURL_TO_MOBILE = os.getenv("PCURL_TO_MOBILE")
 RUN_HEADLESS = os.getenv("RUN_HEADLESS", "true").lower() != "false"
 LOGIN_IS_EDGE = os.getenv("LOGIN_IS_EDGE", "false").lower() == "true"
+RUNNING_IN_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false").lower() == "true"
 AI_DEBUG_MODE = os.getenv("AI_DEBUG_MODE", "false").lower() == "true"
 
 # 检查配置是否齐全
@@ -693,8 +694,11 @@ async def scrape_xianyu(task_config: dict, debug_limit: int = 0):
         if LOGIN_IS_EDGE:
             browser = await p.chromium.launch(headless=RUN_HEADLESS, channel="msedge")
         else:
-            # 明确指定使用系统安装的 Chrome 浏览器，以绕过 Playwright 的内部浏览器管理问题
-            browser = await p.chromium.launch(headless=RUN_HEADLESS, channel="chrome")
+            # Docker环境内，使用Playwright自带的chromium；本地环境，使用系统安装的Chrome
+            if RUNNING_IN_DOCKER:
+                browser = await p.chromium.launch(headless=RUN_HEADLESS)
+            else:
+                browser = await p.chromium.launch(headless=RUN_HEADLESS, channel="chrome")
         context = await browser.new_context(storage_state=STATE_FILE, user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
         page = await context.new_page()
 


### PR DESCRIPTION
新增 RUNNING_IN_DOCKER 环境变量，用于在 Dockerfile 中标记运行环境。
根据此环境变量，在 login.py 和 spider_v2.py 中调整 Playwright 浏览器启动方式：
- Docker 环境下使用 Playwright 默认的 Chromium。
- 本地环境下尝试使用系统安装的 Chrome。 此举旨在提高 Playwright 在不同部署环境下的兼容性和稳定性。