### PR TITLE
修复Webhook通知配置中占位符在Windows系统下丢失的问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,8 @@ WEBHOOK_URL="" # 你的 Webhook URL, 例如: https://foo.bar.com/quz?a=b
 WEBHOOK_METHOD="POST" # 请求方法: "GET" 或 "POST"
 WEBHOOK_HEADERS='{"X-API-TOKEN":"your-secret-token"}' # 自定义请求头 (JSON格式)
 WEBHOOK_CONTENT_TYPE="JSON" # POST请求内容类型: "JSON" 或 "FORM"
-WEBHOOK_QUERY_PARAMETERS='{"title":"${title}","content":"${content}"}' # GET请求的查询参数 (JSON格式, 支持 ${title}, ${content} 占位符)
-WEBHOOK_BODY='{"title":"${title}","content":"${content}"}' # POST请求的请求体 (JSON格式, 支持 ${title}, ${content} 占位符)
+WEBHOOK_QUERY_PARAMETERS='{"title":"{{title}}","content":"{{content}}"}' # GET请求的查询参数 (JSON格式, 支持 {{title}}, {{content}} 占位符)
+WEBHOOK_BODY='{"title":"{{title}}","content":"{{content}}"}' # POST请求的请求体 (JSON格式, 支持 {{title}}, {{content}} 占位符)
 
 # 是否使用edge浏览器 默认使用chrome浏览器
 LOGIN_IS_EDGE=false

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ pip install -r requirements.txt
     | `WEBHOOK_METHOD` | (可选) Webhook 请求方法。 | 否 | 支持 `GET` 或 `POST`，默认为 `POST`。 |
     | `WEBHOOK_HEADERS` | (可选) Webhook 的自定义请求头。 | 否 | 必须是有效的 JSON 字符串，例如 `'{"Authorization": "Bearer xxx"}'`。 |
     | `WEBHOOK_CONTENT_TYPE` | (可选) POST 请求的内容类型。 | 否 | 支持 `JSON` 或 `FORM`，默认为 `JSON`。 |
-    | `WEBHOOK_QUERY_PARAMETERS` | (可选) GET 请求的查询参数。 | 否 | JSON 字符串，支持 `${title}` 和 `${content}` 占位符。 |
-    | `WEBHOOK_BODY` | (可选) POST 请求的请求体。 | 否 | JSON 字符串，支持 `${title}` 和 `${content}` 占位符。 |
+    | `WEBHOOK_QUERY_PARAMETERS` | (可选) GET 请求的查询参数。 | 否 | JSON 字符串，支持 `{{title}}` 和 `{{content}}` 占位符。 |
+    | `WEBHOOK_BODY` | (可选) POST 请求的请求体。 | 否 | JSON 字符串，支持 `{{title}}` 和 `{{content}}` 占位符。 |
     | `LOGIN_IS_EDGE` | 是否使用 Edge 浏览器进行登录和爬取。 | 否 | 默认为 `false`，使用 Chrome/Chromium。 |
     | `PCURL_TO_MOBILE` | 是否在通知中将电脑版商品链接转换为手机版。 | 否 | 默认为 `true`。 |
     | `RUN_HEADLESS` | 是否以无头模式运行爬虫浏览器。 | 否 | 默认为 `true`。在本地调试遇到验证码时可设为 `false` 手动处理。**Docker部署时必须为 `true`**。 |

--- a/src/ai_handler.py
+++ b/src/ai_handler.py
@@ -246,7 +246,11 @@ async def send_ntfy_notification(product_data, reason):
             def replace_placeholders(template_str):
                 if not template_str:
                     return ""
-                return template_str.replace("${title}", notification_title).replace("${content}", message)
+                # 对内容进行JSON转义，避免换行符和特殊字符破坏JSON格式
+                safe_title = json.dumps(notification_title, ensure_ascii=False)[1:-1]  # 去掉外层引号
+                safe_content = json.dumps(message, ensure_ascii=False)[1:-1]  # 去掉外层引号
+                # 同时支持旧的${title}${content}和新的{{title}}{{content}}格式
+                return template_str.replace("${title}", safe_title).replace("${content}", safe_content).replace("{{title}}", safe_title).replace("{{content}}", safe_content)
 
             # 准备请求头
             headers = {}


### PR DESCRIPTION
- 将.env.example中的占位符从改为{{title}}{{content}}格式
- 更新src/ai_handler.py中的替换逻辑，同时支持新旧两种占位符格式
- 更新README.md中的相关文档说明

该修复解决了在Windows系统PowerShell环境下，.env文件中的占位符被当作环境变量展开而丢失的问题。

🤖 Generated with [Claude Code](https://claude.ai/code)