### PR TITLE
修复web_server.py中clear_logs函数的编码问题

### DIFF
--- a/web_server.py
+++ b/web_server.py
@@ -617,7 +617,7 @@ async def clear_logs():
 
     try:
         # 使用 'w' 模式打开文件会清空内容
-        async with aiofiles.open(log_file_path, 'w') as f:
+        async with aiofiles.open(log_file_path, 'w', encoding='utf-8') as f:
             await f.write("")
         return {"message": "日志已成功清空。"}
     except Exception as e:


### PR DESCRIPTION
在Windows系统上，当使用aiofiles.open()函数打开文件进行写入操作时，如果没有明确指定编码格式，会使用系统默认编码（通常是GBK）。当程序尝试写入包含某些特殊字符的内容时就会出现编码错误。

此修复通过在aiofiles.open()调用中明确指定encoding='utf-8'参数来解决此问题。

🐛 Bug fix

🤖 Generated with [Claude Code](https://claude.ai/code)