### PR TITLE
修复Docker部署时因环境变量中包含不可打印字符导致的客户端初始化错误

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,10 @@ if BASE_URL:
     BASE_URL = ''.join(char for char in BASE_URL if char.isprintable()).strip()
 MODEL_NAME = os.getenv("OPENAI_MODEL_NAME")
 PROXY_URL = os.getenv("PROXY_URL")
+# 清理PROXY_URL中的不可打印字符
+if PROXY_URL:
+    # 移除常见的不可打印字符，包括回车符(\r)、换行符(\n)、制表符(\t)等
+    PROXY_URL = ''.join(char for char in PROXY_URL if char.isprintable()).strip()
 NTFY_TOPIC_URL = os.getenv("NTFY_TOPIC_URL")
 GOTIFY_URL = os.getenv("GOTIFY_URL")
 GOTIFY_TOKEN = os.getenv("GOTIFY_TOKEN")

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,10 @@ DETAIL_API_URL_PATTERN = "h5api.m.goofish.com/h5/mtop.taobao.idle.pc.detail"
 # --- Environment Variables ---
 API_KEY = os.getenv("OPENAI_API_KEY")
 BASE_URL = os.getenv("OPENAI_BASE_URL")
+# 清理BASE_URL中的不可打印字符
+if BASE_URL:
+    # 移除常见的不可打印字符，包括回车符(\r)、换行符(\n)、制表符(\t)等
+    BASE_URL = ''.join(char for char in BASE_URL if char.isprintable()).strip()
 MODEL_NAME = os.getenv("OPENAI_MODEL_NAME")
 PROXY_URL = os.getenv("PROXY_URL")
 NTFY_TOPIC_URL = os.getenv("NTFY_TOPIC_URL")


### PR DESCRIPTION
修复了Docker部署时因环境变量中包含不可打印字符（如回车符、换行符等）导致的客户端初始化错误

- 在src/config.py中添加了对BASE_URL和PROXY_URL环境变量的清理逻辑
- 自动移除URL中的不可打印字符（如回车符、换行符等）
- 提高程序在不同环境下的健壮性

🤖 Generated with [Claude Code](https://claude.ai/code)