### PR TITLE
修复OpenAI API调用404错误

### DIFF
--- a/src/ai_handler.py
+++ b/src/ai_handler.py
@@ -407,10 +407,11 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
 
     messages = [{"role": "user", "content": user_content_list}]
 
+    # 移除 response_format 参数以提高与不同API提供商的兼容性
+    # 某些提供商(如阿里云Dashscope)可能不支持此参数导致404错误
     response = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=messages,
-        response_format={"type": "json_object"}
+        messages=messages
     )
 
     ai_response_content = response.choices[0].message.content

--- a/src/prompt_utils.py
+++ b/src/prompt_utils.py
@@ -67,7 +67,15 @@ async def generate_criteria(user_description: str, reference_file_path: str) -> 
         print("AI已成功生成内容。")
         return generated_text.strip()
     except Exception as e:
-        print(f"调用 OpenAI API 时出错: {e}")
+        # 增强错误日志，显示更多详细信息以便于调试
+        error_details = f"调用 OpenAI API 时出错: {type(e).__name__}: {e}"
+        if hasattr(e, 'response') and e.response is not None:
+            error_details += f"\nHTTP状态码: {e.response.status_code}"
+            try:
+                error_details += f"\n响应内容: {e.response.text}"
+            except:
+                error_details += "\n无法获取响应内容"
+        print(error_details)
         raise e
 
 


### PR DESCRIPTION
本次提交修复了OpenAI API调用404错误，主要包括:

1. 移除了不兼容的response_format参数
2. 增强了错误日志，方便调试

这些修改应能解决您遇到的404错误问题。
