### PR TITLE
fix: 添加后端容器内AI连接测试功能

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -568,7 +568,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 </div>
                 
                 <div class="form-group">
-                    <button type="button" id="test-ai-settings-btn" class="control-button">测试连接</button>
+                    <button type="button" id="test-ai-settings-btn" class="control-button">测试连接（浏览器）</button>
+                    <button type="button" id="test-ai-settings-backend-btn" class="control-button">测试连接（后端容器）</button>
                     <button type="submit" class="control-button primary-btn">保存AI设置</button>
                 </div>
             </form>
@@ -1106,7 +1107,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 saveBtn.textContent = originalText;
             });
 
-            // Add event listener for AI settings test button
+            // Add event listener for AI settings test button (browser)
             const testBtn = document.getElementById('test-ai-settings-btn');
             if (testBtn) {
                 testBtn.addEventListener('click', async () => {
@@ -1129,12 +1130,48 @@ document.addEventListener('DOMContentLoaded', function () {
                         if (result.success) {
                             alert(result.message || "AI模型连接测试成功！");
                         } else {
-                            alert("测试失败: " + result.message);
+                            alert("浏览器测试失败: " + result.message);
                         }
                     }
                     
                     testBtn.disabled = false;
                     testBtn.textContent = originalText;
+                });
+            }
+
+            // Add event listener for AI settings test button (backend)
+            const testBackendBtn = document.getElementById('test-ai-settings-backend-btn');
+            if (testBackendBtn) {
+                testBackendBtn.addEventListener('click', async () => {
+                    // Test backend settings without form data (uses env config)
+                    const originalText = testBackendBtn.textContent;
+                    testBackendBtn.disabled = true;
+                    testBackendBtn.textContent = '测试中...';
+                    
+                    try {
+                        const response = await fetch('/api/settings/ai/test/backend', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                            },
+                        });
+                        
+                        if (!response.ok) {
+                            throw new Error('后端测试请求失败');
+                        }
+                        
+                        const result = await response.json();
+                        if (result.success) {
+                            alert(result.message || "后端AI模型连接测试成功！");
+                        } else {
+                            alert("后端容器测试失败: " + result.message);
+                        }
+                    } catch (error) {
+                        alert("后端容器测试错误: " + error.message);
+                    }
+                    
+                    testBackendBtn.disabled = false;
+                    testBackendBtn.textContent = originalText;
                 });
             }
         }

--- a/web_server.py
+++ b/web_server.py
@@ -1103,6 +1103,42 @@ async def test_ai_settings(settings: dict, username: str = Depends(verify_creden
         }
 
 
+@app.post("/api/settings/ai/test/backend", response_model=dict)
+async def test_ai_settings_backend(username: str = Depends(verify_credentials)):
+    """
+    测试AI模型设置是否有效（从后端容器内发起）。
+    """
+    try:
+        from src.config import client, MODEL_NAME
+        
+        # 使用与spider_v2.py相同的AI客户端配置
+        if not client:
+            return {
+                "success": False, 
+                "message": "后端AI客户端未初始化，请检查.env配置文件中的AI设置。"
+            }
+        
+        # 测试连接
+        response = client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[
+                {"role": "user", "content": "Hello, this is a test message from backend container to verify connection."}
+            ],
+            max_tokens=10
+        )
+        
+        return {
+            "success": True, 
+            "message": "后端AI模型连接测试成功！容器网络正常。",
+            "response": response.choices[0].message.content if response.choices else "No response"
+        }
+    except Exception as e:
+        return {
+            "success": False, 
+            "message": f"后端AI模型连接测试失败: {str(e)}。这表明容器内网络可能存在问题。"
+        }
+
+
 if __name__ == "__main__":
     # 从 .env 文件加载环境变量
     config = dotenv_values(".env")


### PR DESCRIPTION
# 摘要
解决用户在设置页面测试AI不报错但创建任务时报错的问题。

# 问题分析
- 用户在设置页面的AI测试不报错
- 但创建任务时出现"AI生成失败"错误
- 原因是测试从浏览器发起，无法发现容器内网络问题

# 解决方案
1. 新增后端API端点 `/api/settings/ai/test/backend`
2. 在前端设置页面添加"测试连接（后端容器）"按钮
3. 使用与spider_v2.py相同的AI客户端配置
4. 提供详细的错误信息帮助排查网络问题

# 改动内容
- `web_server.py`: 新增后端容器内AI测试端点
- `static/js/main.js`: 新增按钮和相关事件处理逻辑

# 效果
- 用户可以区分配置问题和网络问题
- 更快地定位问题根源

# 相关问题
- 关闭 # 0

Generated with [Claude Code](https://claude.ai/code)