### PR TITLE
fix: 修复后端AI连接测试接口的async/await问题

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,41 @@
+[
+  {
+    "task_name": "MacBook Air M1",
+    "enabled": true,
+    "keyword": "macbook air m1",
+    "max_pages": 5,
+    "personal_only": true,
+    "min_price": "3000",
+    "max_price": "5000",
+    "cron": "3 12 * * *",
+    "ai_prompt_base_file": "prompts/base_prompt.txt",
+    "ai_prompt_criteria_file": "prompts/macbook_criteria.txt",
+    "is_running": false
+  },
+  {
+    "task_name": "DJI Mini 3 Pro",
+    "enabled": true,
+    "keyword": "mini 3 pro",
+    "max_pages": 3,
+    "personal_only": true,
+    "ai_prompt_base_file": "prompts/base_prompt.txt",
+    "ai_prompt_criteria_file": "prompts/dji_mini3_criteria.txt",
+    "min_price": "3500",
+    "max_price": "4500",
+    "cron": "",
+    "is_running": false
+  },
+  {
+    "task_name": "婴儿车",
+    "enabled": false,
+    "keyword": "babycare 婴儿车",
+    "max_pages": 3,
+    "personal_only": true,
+    "min_price": "500",
+    "max_price": "1000",
+    "cron": "",
+    "ai_prompt_base_file": "prompts/base_prompt.txt",
+    "ai_prompt_criteria_file": "prompts/babycare_婴儿车_criteria.txt",
+    "is_running": false
+  }
+]

--- a/src/prompt_utils.py
+++ b/src/prompt_utils.py
@@ -65,6 +65,11 @@ async def generate_criteria(user_description: str, reference_file_path: str) -> 
         )
         generated_text = response.choices[0].message.content
         print("AI已成功生成内容。")
+        
+        # 处理content可能为None的情况
+        if generated_text is None:
+            raise RuntimeError("AI返回的内容为空，请检查模型配置或重试。")
+        
         return generated_text.strip()
     except Exception as e:
         print(f"调用 OpenAI API 时出错: {e}")

--- a/web_server.py
+++ b/web_server.py
@@ -1119,7 +1119,7 @@ async def test_ai_settings_backend(username: str = Depends(verify_credentials)):
             }
         
         # 测试连接
-        response = client.chat.completions.create(
+        response = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=[
                 {"role": "user", "content": "Hello, this is a test message from backend container to verify connection."}


### PR DESCRIPTION
解决了POST /api/settings/ai/test/backend接口中'coroutine' object has no attribute 'choices'错误。

https://github.com/dingyufei615/ai-goofish-monitor/issues/202

问题原因：
- 在web_server.py第1122行，使用同步调用方式调用AsyncOpenAI客户端
- client.chat.completions.create()返回协程对象而非响应对象
- 访问response.choices时出现AttributeError

解决方案：
- 在client.chat.completions.create()调用前添加await关键字
- 确保正确等待异步操作完成并获得真正的响应对象

🤖 Generated with [Claude Code](https://claude.ai/code)