### PR TITLE
feat(config): 添加 ENABLE_THINKING 环境变量控制

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ RUN_HEADLESS=true
 # (可选) AI调试模式 (true/false)。开启后会在控制台打印更多用于排查AI分析问题的日志。
 AI_DEBUG_MODE=false
 
+# 是否启用enable_thinking参数 (true/false)。某些AI模型需要此参数，而有些则不支持。
+ENABLE_THINKING=false
+
 # 服务端口自定义 不配置默认8000
 SERVER_PORT=8000
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -35,9 +35,17 @@
 *   `OPENAI_MODEL_NAME`: 你要使用的具体模型名称，需要模型支持图片识别，例如 `gemini-2.5-flash`。
 - **示例:** 如果你的服务商文档说 Completions 接口是 `https://xx.xx.com/v1/chat/completions`，那么 `OPENAI_BASE_URL` 就应该填 `https://xx.xx.com/v1`。
 
+#### 问：为什么AI模型连接测试失败，提示 "Invalid JSON payload received. Unknown name "enable_thinking": Cannot find field" 错误？
+
+**答：** 这是因为某些AI模型不支持 `enable_thinking` 参数导致的。项目现在支持通过环境变量 `ENABLE_THINKING` 来控制是否添加这个参数：
+
+*   **解决方案：** 在 `.env` 文件中设置 `ENABLE_THINKING=false`，然后重新运行AI模型连接测试。
+*   **默认行为：** 从项目v1.0版本开始，默认情况下 `ENABLE_THINKING` 设置为 `false`，不会添加 `enable_thinking` 参数，以兼容更多AI模型。
+*   **特殊需求：** 如果你使用的AI模型需要这个参数，可以将 `ENABLE_THINKING` 设置为 `true`。
+
 ---
 
-### **Q2: 登录与反爬虫**
+### **Q3: 登录与反爬虫**
 
 #### 问：为什么 `xianyu_state.json` 文件会自动消失？
 
@@ -53,7 +61,7 @@
 
 ---
 
-### **Q3: 环境与部署**
+### **Q4: 环境与部署**
 
 #### 问：运行 `login.py` 或 `spider_v2.py` 时出现 `'gbk' codec can't encode character` 相关的编码错误？
 **答:** 这是典型的 Windows 环境下的编码问题。项目代码和日志默认使用 UTF-8 编码。
@@ -138,7 +146,7 @@ docker run --shm-size=1gb -v "$(pwd)":/app ai-goofish-monitor
 
 ---
 
-### **Q4: 功能使用问题**
+### **Q5: 功能使用问题**
 
 #### 问：如何设置定时任务的执行频率？
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ pip install -r requirements.txt
     | `RUN_HEADLESS` | 是否以无头模式运行爬虫浏览器。 | 否 | 默认为 `true`。在本地调试遇到验证码时可设为 `false` 手动处理。**Docker部署时必须为 `true`**。 |
     | `AI_DEBUG_MODE` | 是否开启AI调试模式。 | 否 | 默认为 `false`。开启后会在控制台打印详细的AI请求和响应日志。 |
     | `SKIP_AI_ANALYSIS` | 是否跳过AI分析并直接发送通知。 | 否 | 默认为 `false`。设置为 `true` 时，所有爬取到的商品将直接发送通知而不经过AI分析。 |
+    | `ENABLE_THINKING` | 是否启用enable_thinking参数。 | 否 | 默认为 `false`。某些AI模型需要此参数，而有些则不支持。如果遇到"Invalid JSON payload received. Unknown name "enable_thinking""错误，请尝试设置为 `false`。 |
     | `SERVER_PORT` | Web UI服务的运行端口。 | 否 | 默认为 `8000`。 |
     | `WEB_USERNAME` | Web界面登录用户名。 | 否 | 默认为 `admin`。生产环境请务必修改。 |
     | `WEB_PASSWORD` | Web界面登录密码。 | 否 | 默认为 `admin123`。生产环境请务必修改为强密码。 |

--- a/src/ai_handler.py
+++ b/src/ai_handler.py
@@ -528,13 +528,16 @@ async def get_ai_analysis(product_data, image_paths=None, prompt_text=""):
             # 根据重试次数调整参数
             current_temperature = 0.1 if attempt == 0 else 0.05  # 重试时使用更低的温度
 
+            from src.config import get_ai_request_params
+            
             response = await client.chat.completions.create(
-                model=MODEL_NAME,
-                messages=messages,
-                response_format={"type": "json_object"},
-                temperature=current_temperature,
-                max_tokens=4000,
-                extra_body={"enable_thinking": False}
+                **get_ai_request_params(
+                    model=MODEL_NAME,
+                    messages=messages,
+                    response_format={"type": "json_object"},
+                    temperature=current_temperature,
+                    max_tokens=4000
+                )
             )
 
             ai_response_content = response.choices[0].message.content

--- a/src/config.py
+++ b/src/config.py
@@ -42,6 +42,7 @@ LOGIN_IS_EDGE = os.getenv("LOGIN_IS_EDGE", "false").lower() == "true"
 RUNNING_IN_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false").lower() == "true"
 AI_DEBUG_MODE = os.getenv("AI_DEBUG_MODE", "false").lower() == "true"
 SKIP_AI_ANALYSIS = os.getenv("SKIP_AI_ANALYSIS", "false").lower() == "true"
+ENABLE_THINKING = os.getenv("ENABLE_THINKING", "false").lower() == "true"
 
 # --- Headers ---
 IMAGE_DOWNLOAD_HEADERS = {
@@ -81,3 +82,11 @@ if not client:
 # 检查关键配置
 if not all([BASE_URL, MODEL_NAME]) and 'prompt_generator.py' in sys.argv[0]:
     sys.exit("错误：请确保在 .env 文件中完整设置了 OPENAI_BASE_URL 和 OPENAI_MODEL_NAME。(OPENAI_API_KEY 对于某些服务是可选的)")
+
+def get_ai_request_params(**kwargs):
+    """
+    构建AI请求参数，根据ENABLE_THINKING环境变量决定是否添加enable_thinking参数
+    """
+    if ENABLE_THINKING:
+        kwargs["extra_body"] = {"enable_thinking": False}
+    return kwargs

--- a/src/prompt_utils.py
+++ b/src/prompt_utils.py
@@ -58,11 +58,14 @@ async def generate_criteria(user_description: str, reference_file_path: str) -> 
 
     print("正在调用AI生成新的分析标准，请稍候...")
     try:
+        from src.config import get_ai_request_params
+        
         response = await client.chat.completions.create(
-            model=MODEL_NAME,
-            messages=[{"role": "user", "content": prompt}],
-            temperature=0.5, # Lower temperature for more predictable structure
-            extra_body={"enable_thinking": False}
+            **get_ai_request_params(
+                model=MODEL_NAME,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.5 # Lower temperature for more predictable structure
+            )
         )
         generated_text = response.choices[0].message.content
         print("AI已成功生成内容。")

--- a/web_server.py
+++ b/web_server.py
@@ -1097,14 +1097,17 @@ async def test_ai_settings(settings: dict, username: str = Depends(verify_creden
 
         client = OpenAI(**client_params)
 
+        from src.config import get_ai_request_params
+        
         # 测试连接
         response = client.chat.completions.create(
-            model=mode_name,
-            messages=[
-                {"role": "user", "content": "Hello, this is a test message to verify the connection."}
-            ],
-            max_tokens=10,
-            extra_body={"enable_thinking": False}
+            **get_ai_request_params(
+                model=mode_name,
+                messages=[
+                    {"role": "user", "content": "Hello, this is a test message to verify the connection."}
+                ],
+                max_tokens=10
+            )
         )
 
         return {
@@ -1134,15 +1137,18 @@ async def test_ai_settings_backend(username: str = Depends(verify_credentials)):
                 "message": "后端AI客户端未初始化，请检查.env配置文件中的AI设置。"
             }
 
+        from src.config import get_ai_request_params
+        
         print(f"LOG: 后端容器AI测试 BASE_URL: {BASE_URL}, MODEL_NAME: {MODEL_NAME}")
         # 测试连接
         response = await client.chat.completions.create(
-            model=MODEL_NAME,
-            messages=[
-                {"role": "user", "content": "Hello, this is a test message from backend container to verify connection."}
-            ],
-            max_tokens=10,
-            extra_body={"enable_thinking": False}
+            **get_ai_request_params(
+                model=MODEL_NAME,
+                messages=[
+                    {"role": "user", "content": "Hello, this is a test message from backend container to verify connection."}
+                ],
+                max_tokens=10
+            )
         )
 
         return {


### PR DESCRIPTION
- 在 .env.example 和 config.py 中添加 ENABLE_THINKING 环境变量
- 修改 ai_handler.py、prompt_utils.py 和 web_server.py，根据 ENABLE_THINKING 设置决定是否添加 enable_thinking 参数
- 更新 README.md 和 FAQ.md，说明 ENABLE_THINKING 的用途和默认值